### PR TITLE
Add escape argument to formula for mysql grants

### DIFF
--- a/mysql/salt-user.sls
+++ b/mysql/salt-user.sls
@@ -40,6 +40,7 @@ mysql_salt_user_with_salt_user_grants:
     - grant_option: True
     - user: {{ mysql_salt_user }}
     - host: '{{ host }}'
+    - escape: {{ db['escape'] | default(True) }}
     - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_salt_user }}'
     - connection_pass: '{{ mysql_salt_pass }}'
@@ -77,6 +78,7 @@ mysql_salt_user_with_root_user_grants:
     - grant_option: True
     - user: {{ mysql_salt_user }}
     - host: '{{ host }}'
+    - escape: {{ db['escape'] | default(True) }}
     - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_root_user }}'
     - connection_pass: '{{ mysql_root_pass }}'
@@ -113,6 +115,7 @@ mysql_salt_user_with_passwordless_root_user_grants:
     - grant_option: True
     - user: {{ mysql_salt_user }}
     - host: '{{ host }}'
+    - escape: {{ db['escape'] | default(True) }}
     - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_root_user }}'
     - connection_charset: utf8

--- a/mysql/user.sls
+++ b/mysql/user.sls
@@ -51,6 +51,7 @@ include:
     - grant_option: {{ user['grant_option'] | default(False) }}
     - user: {{ name }}
     - host: '{{ host }}'
+    - escape: {{ db['escape'] | default(True) }}
     - connection_host: localhost
     - connection_user: '{{ mysql_salt_user }}'
     {% if mysql_salt_pass -%}
@@ -71,6 +72,7 @@ include:
     - grant_option: {{ db['grant_option'] | default(False) }}
     - user: {{ name }}
     - host: '{{ host }}'
+    - escape: {{ db['escape'] | default(True) }}
     - connection_host: '{{ mysql_host }}'
     - connection_user: '{{ mysql_salt_user }}'
     {% if mysql_salt_pass -%}


### PR DESCRIPTION
This is needed to make 'wildcard' grants. Note you'll still need to double
up on the % and wrap in backticks as per the following example:

mysql:
  user:
    ci_admin:
      databases:
        - database: "`dashboard_ci_%%`"
          table: '*'
          grants: ['all privileges']
          escape: False

The above grants user `ci_admin` full access to databases that start with
'dashboard_ci_'.
