### PR TITLE
Make parent directories for my.cnf

### DIFF
--- a/mysql/config.sls
+++ b/mysql/config.sls
@@ -62,6 +62,7 @@ mysql_config:
     - source: salt://mysql/files/my-include.cnf
 {% else %}
     - source: salt://mysql/files/my.cnf
+    - makedirs: True
 {% endif %}
     {% if os_family in ['Debian', 'Gentoo', 'RedHat'] %}
     - user: root


### PR DESCRIPTION
+ we use /srv/docker/mariadb/etc/mysql/my.cnf

BOS-15312